### PR TITLE
Add JustAfterEach

### DIFF
--- a/ginkgo_dsl.go
+++ b/ginkgo_dsl.go
@@ -550,6 +550,16 @@ func JustBeforeEach(body interface{}, timeout ...float64) bool {
 	return true
 }
 
+//JustAfterEach blocks are run after It blocks but *before* all AfterEach blocks.  For more details,
+//read the [documentation](http://onsi.github.io/ginkgo/#separating_creation_and_configuration_)
+//
+//Like It blocks, JustAfterEach blocks can be made asynchronous by providing a body function that accepts
+//a Done channel
+func JustAfterEach(body interface{}, timeout ...float64) bool {
+	globalSuite.PushJustAfterEachNode(body, codelocation.New(1), parseTimeout(timeout...))
+	return true
+}
+
 //AfterEach blocks are run after It blocks.   When multiple AfterEach blocks are defined in nested
 //Describe and Context blocks the innermost AfterEach blocks are run first.
 //

--- a/internal/leafnodes/setup_nodes.go
+++ b/internal/leafnodes/setup_nodes.go
@@ -39,3 +39,9 @@ func NewJustBeforeEachNode(body interface{}, codeLocation types.CodeLocation, ti
 		runner: newRunner(body, codeLocation, timeout, failer, types.SpecComponentTypeJustBeforeEach, componentIndex),
 	}
 }
+
+func NewJustAfterEachNode(body interface{}, codeLocation types.CodeLocation, timeout time.Duration, failer *failer.Failer, componentIndex int) *SetupNode {
+	return &SetupNode{
+		runner: newRunner(body, codeLocation, timeout, failer, types.SpecComponentTypeJustAfterEach, componentIndex),
+	}
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -140,6 +140,18 @@ func (spec *Spec) runSample(sample int, writer io.Writer) {
 	defer func() {
 		for i := innerMostContainerIndexToUnwind; i >= 0; i-- {
 			container := spec.containers[i]
+			for _, justAfterEach := range container.SetupNodesOfType(types.SpecComponentTypeJustAfterEach) {
+				spec.announceSetupNode(writer, "JustAfterEach", container, justAfterEach)
+				justAfterEachState, justAfterEachFailure := justAfterEach.Run()
+				if justAfterEachState != types.SpecStatePassed && spec.state == types.SpecStatePassed {
+					spec.state = justAfterEachState
+					spec.failure = justAfterEachFailure
+				}
+			}
+		}
+
+		for i := innerMostContainerIndexToUnwind; i >= 0; i-- {
+			container := spec.containers[i]
 			for _, afterEach := range container.SetupNodesOfType(types.SpecComponentTypeAfterEach) {
 				spec.announceSetupNode(writer, "AfterEach", container, afterEach)
 				afterEachState, afterEachFailure := afterEach.Run()

--- a/internal/suite/suite.go
+++ b/internal/suite/suite.go
@@ -163,6 +163,13 @@ func (suite *Suite) PushJustBeforeEachNode(body interface{}, codeLocation types.
 	suite.currentContainer.PushSetupNode(leafnodes.NewJustBeforeEachNode(body, codeLocation, timeout, suite.failer, suite.containerIndex))
 }
 
+func (suite *Suite) PushJustAfterEachNode(body interface{}, codeLocation types.CodeLocation, timeout time.Duration) {
+	if suite.running {
+		suite.failer.Fail("You may only call JustAfterEach from within a Describe or Context", codeLocation)
+	}
+	suite.currentContainer.PushSetupNode(leafnodes.NewJustAfterEachNode(body, codeLocation, timeout, suite.failer, suite.containerIndex))
+}
+
 func (suite *Suite) PushAfterEachNode(body interface{}, codeLocation types.CodeLocation, timeout time.Duration) {
 	if suite.running {
 		suite.failer.Fail("You may only call AfterEach from within a Describe or Context", codeLocation)

--- a/types/types.go
+++ b/types/types.go
@@ -146,6 +146,7 @@ const (
 	SpecComponentTypeAfterSuite
 	SpecComponentTypeBeforeEach
 	SpecComponentTypeJustBeforeEach
+	SpecComponentTypeJustAfterEach
 	SpecComponentTypeAfterEach
 	SpecComponentTypeIt
 	SpecComponentTypeMeasure


### PR DESCRIPTION
**What this PR does / why we need it**:

In the kubernetes end to end tests (which use Ginkgo), the structure is that there is a general framework and then specific test cases.  Both have BeforeEach and AfterEach statements and the execution order is 
```
Framework BeforeEach
  Test BeforeEach
    Test runs
  Test AfterEach
Framework AfterEach.
```
Quite often, the Test's BeforeEach sets up some infrastructure required for the test and the AfterEach tears it down.

However, if a test fails, we want to collect diags as close to the failure as possible.  We *could* find and modify all the innermost AfterEach's and add diags to them all.  But it would be much nicer to be able to have a JustAfterEach in the Framework that all the tests use that works in a similar way to JustBeforeEach.

This problem was mentioned in https://github.com/kubernetes/kubernetes/issues/34318, although that wasn't explicitly about this.
